### PR TITLE
DRY up the fetcher specs by using shared_examples

### DIFF
--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '../..', 'utils', 'fetchers'))
+
+RSpec.shared_examples 'a fetcher' do
+  it 'raises error on nil client' do
+    expect {described_class.fetch(nil, "fsadfj823w")}.to raise_error(Trello::Error)
+  end
+
+  it 'raises error on nil member token' do
+    expect {described_class.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
+  end
+
+  it 'raises error on empty member token' do
+    expect {described_class.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
+  end
+end

--- a/test/spec/utils/fetchers/board_details_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/board_details_fetcher_spec.rb
@@ -1,19 +1,11 @@
-require_relative '../../../../utils/fetchers/board_details_fetcher'
+require_relative '../../spec_helper'
+require 'board_details_fetcher'
 
 describe BoardDetailsFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {BoardDetailsFetcher.fetch(nil, "fsadfj823w")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil board id' do
-      expect {BoardDetailsFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on empty board id' do
-      expect {BoardDetailsFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-    
     it 'uses client to get details' do
       board_id = "fsadfj823w"
       options = {filter: :open, lists: :open, fields: :name}

--- a/test/spec/utils/fetchers/board_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/board_fetcher_spec.rb
@@ -1,19 +1,11 @@
-require_relative '../../../../utils/fetchers/board_fetcher'
+require_relative '../../spec_helper'
+require 'board_fetcher'
 
 describe BoardFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {BoardFetcher.fetch(nil, "bensisko")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil member id' do
-      expect {BoardFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on empty member id' do
-      expect {BoardFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-
     it 'uses client to get member boards' do
       member_id = "bensisko"
       options = {filter: :open, fields: :name, organization: true}

--- a/test/spec/utils/fetchers/label_count_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/label_count_fetcher_spec.rb
@@ -1,20 +1,11 @@
-require_relative '../../../../utils/fetchers/label_count_fetcher'
-require 'date'
+require_relative '../../spec_helper'
+require 'label_count_fetcher'
 
 describe LabelCountFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {LabelCountFetcher.fetch(nil, "ori0kf34rf34jfjfrej")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil board id' do
-      expect {LabelCountFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on empty board id' do
-      expect {LabelCountFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-    
     it 'uses client to get board' do
       board_id = "ori0kf34rf34jfjfrej"
       options = {:fields=>"color,name,uses", :limit=>100}

--- a/test/spec/utils/fetchers/member_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/member_fetcher_spec.rb
@@ -1,19 +1,11 @@
-require_relative '../../../../utils/fetchers/member_fetcher'
+require_relative '../../spec_helper'
+require 'member_fetcher'
 
 describe MemberFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {MemberFetcher.fetch(nil, "fsadfj823w")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil member token' do
-      expect {MemberFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on empty member token' do
-      expect {MemberFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-    
     it 'uses client to get specified data' do
       token = "fsadfj823w"
       options = {fields: "username,gravatarHash,email"}

--- a/test/spec/utils/fetchers/progress_charts_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/progress_charts_fetcher_spec.rb
@@ -1,20 +1,11 @@
-require_relative '../../../../utils/fetchers/progress_charts_fetcher'
-require 'date'
+require_relative '../../spec_helper'
+require 'progress_charts_fetcher'
 
 describe ProgressChartsFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {ProgressChartsFetcher.fetch(nil, "ori0kf34rf34jfjfrej")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil board id' do
-      expect {ProgressChartsFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on empty board id' do
-      expect {ProgressChartsFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-
     it 'uses client to get board' do
       board_id = "ori0kf34rf34jfjfrej"
       options = {

--- a/test/spec/utils/fetchers/stats_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/stats_fetcher_spec.rb
@@ -1,20 +1,11 @@
-require_relative '../../../../utils/fetchers/stats_fetcher'
-require 'date'
+require_relative '../../spec_helper'
+require 'stats_fetcher'
 
 describe StatsFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {StatsFetcher.fetch(nil, "fsadfj823w")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil board id' do
-      expect {StatsFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil empty id' do
-      expect {StatsFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-    
     it 'uses client to get board data' do
       board_id = "fsadfj823w"
       options = {

--- a/test/spec/utils/fetchers/wip_fetcher_spec.rb
+++ b/test/spec/utils/fetchers/wip_fetcher_spec.rb
@@ -1,19 +1,11 @@
-require_relative '../../../../utils/fetchers/wip_fetcher'
+require_relative '../../spec_helper'
+require 'wip_fetcher'
 
 describe WipFetcher do
+
+  it_behaves_like 'a fetcher'
+
   describe '#fetch' do
-    it 'raises error on nil client' do
-      expect {WipFetcher.fetch(nil, "fsadfj823w")}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on nil board id' do
-      expect {WipFetcher.fetch(double(Trello::Client), nil)}.to raise_error(Trello::Error)
-    end
-
-    it 'raises error on empty board id' do
-      expect {WipFetcher.fetch(double(Trello::Client), "")}.to raise_error(Trello::Error)
-    end
-    
     it 'uses client to get lists' do
       board_id = "fsadfj823w"
       options = {filter: :open, cards: :open, card_fields: :none}


### PR DESCRIPTION
All of the fetcher specs had the same three checks; moved them into a `shared_examples` called `'a fetcher'`.