### PR TITLE
travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - secure: Nh4Vc1EEgs+C7rqTauvCJaehvsI6hQiYtm/ttzIirDjCJt0P0jgm0ZZoqESItz5SQUEUoQ+tAhkCOmShCkAKjg11XXqY024DYdySypY/eDjF7WoNJeVXS1nIsgPNfpoMKh2yk6t//MmZgeuwb7FuVEoJ63qUpyXDnICHOyfo6m8=
   - secure: Sp/QRPI2M1wGNg14DqsN3N4l6OwKLHEMf7V4qsYnhOIlirEpMfJ3OnG0VHoNwK9Yq/hOaL6g802WvwUgAkNQnyXF85gWFo5bsuDxqogwFWp0bb7s1BAjolZ06z79D+LCtZAsMOFpxFXY+fg1goc8F8XxVOvkwo0wsSNiSKN62aI=
   - secure: N58wuHe+HiUI6L31EBjWplRmErAXb9DdmNJo2lefcjAAUDJfvQF5/qO4pyXRoSBThPygkpx0a4UyR3JblLUdCKebnT5/e7PqEpbImDEpKFwPGa2onA1EcEq+tDgcAuAE8TH1SLC2z/lPKJXmLhvTCx5zRNZ9Z5nzsHZdwpnd1gc=
-  - secure: FNvhD0mL8Q1kT2GUDUEB+wwIyMga/ejt9niYbbRcbZqrBGabeiVf5hDG2QlM/nq7FYXo5IGTkMre9lztKgc5hnGYVRWfOCS57RvEysbE6UTj/aEOWsKDJcmVDajt/dwxlFUrOBCo16QEREsk9xb/V9BvNNr4H8Nn1YaowTmy9g4=
+  - secure: ZHSZ1NPZolBpv3zIwPXS5ulVU0T63dbdQpDX1OitI+Xl/8sE7/YiztR5D5wu0oD2z6Xhxyh9W8fWrg0Puo+iJGwum7+2gZkVPU0wuqcZW2qZ3Th4mHr2loqfu/2N47fFeVYAqV9JmOzDopy41a795Jmle1fGWKG8QYbH26ylzec=
 before_install:
   - sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+rvm: 2.2.0
+notifications:
+  email: false
+script: rake test:all
+env:
+  global:
+  - secure: Nh4Vc1EEgs+C7rqTauvCJaehvsI6hQiYtm/ttzIirDjCJt0P0jgm0ZZoqESItz5SQUEUoQ+tAhkCOmShCkAKjg11XXqY024DYdySypY/eDjF7WoNJeVXS1nIsgPNfpoMKh2yk6t//MmZgeuwb7FuVEoJ63qUpyXDnICHOyfo6m8=
+  - secure: Sp/QRPI2M1wGNg14DqsN3N4l6OwKLHEMf7V4qsYnhOIlirEpMfJ3OnG0VHoNwK9Yq/hOaL6g802WvwUgAkNQnyXF85gWFo5bsuDxqogwFWp0bb7s1BAjolZ06z79D+LCtZAsMOFpxFXY+fg1goc8F8XxVOvkwo0wsSNiSKN62aI=
+  - secure: N58wuHe+HiUI6L31EBjWplRmErAXb9DdmNJo2lefcjAAUDJfvQF5/qO4pyXRoSBThPygkpx0a4UyR3JblLUdCKebnT5/e7PqEpbImDEpKFwPGa2onA1EcEq+tDgcAuAE8TH1SLC2z/lPKJXmLhvTCx5zRNZ9Z5nzsHZdwpnd1gc=
+before_install:
+- sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
+install:
+  - bundle
+  - rake &

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,5 @@ env:
   - secure: U4PjogvxKMIJqhA+Q/xz8PW0j2LL0YlgNoZ1UWkU7NEfxzug0k8CtVP3Wc/yjDOYIqA+5bnINSfWhH2IPNL5VW8zhBq3sLVsPI0AXNaMPCaJqB+MbJ3IztB5MYjkn5oph3lbahw7CwLvFn5d8D3XLG+4Ou/ctNGTccR4aRiqe3I=
 before_install:
   - sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
-install:
-  - bundle
-  - rake &
+install: bundle
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - secure: Sp/QRPI2M1wGNg14DqsN3N4l6OwKLHEMf7V4qsYnhOIlirEpMfJ3OnG0VHoNwK9Yq/hOaL6g802WvwUgAkNQnyXF85gWFo5bsuDxqogwFWp0bb7s1BAjolZ06z79D+LCtZAsMOFpxFXY+fg1goc8F8XxVOvkwo0wsSNiSKN62aI=
   - secure: N58wuHe+HiUI6L31EBjWplRmErAXb9DdmNJo2lefcjAAUDJfvQF5/qO4pyXRoSBThPygkpx0a4UyR3JblLUdCKebnT5/e7PqEpbImDEpKFwPGa2onA1EcEq+tDgcAuAE8TH1SLC2z/lPKJXmLhvTCx5zRNZ9Z5nzsHZdwpnd1gc=
   - secure: ZHSZ1NPZolBpv3zIwPXS5ulVU0T63dbdQpDX1OitI+Xl/8sE7/YiztR5D5wu0oD2z6Xhxyh9W8fWrg0Puo+iJGwum7+2gZkVPU0wuqcZW2qZ3Th4mHr2loqfu/2N47fFeVYAqV9JmOzDopy41a795Jmle1fGWKG8QYbH26ylzec=
+  - secure: U4PjogvxKMIJqhA+Q/xz8PW0j2LL0YlgNoZ1UWkU7NEfxzug0k8CtVP3Wc/yjDOYIqA+5bnINSfWhH2IPNL5VW8zhBq3sLVsPI0AXNaMPCaJqB+MbJ3IztB5MYjkn5oph3lbahw7CwLvFn5d8D3XLG+4Ou/ctNGTccR4aRiqe3I=
 before_install:
   - sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm: 2.2.0
 notifications:
   email: false
 script: rake test:all
+services: mongodb
 env:
   global:
   - secure: Nh4Vc1EEgs+C7rqTauvCJaehvsI6hQiYtm/ttzIirDjCJt0P0jgm0ZZoqESItz5SQUEUoQ+tAhkCOmShCkAKjg11XXqY024DYdySypY/eDjF7WoNJeVXS1nIsgPNfpoMKh2yk6t//MmZgeuwb7FuVEoJ63qUpyXDnICHOyfo6m8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - secure: Nh4Vc1EEgs+C7rqTauvCJaehvsI6hQiYtm/ttzIirDjCJt0P0jgm0ZZoqESItz5SQUEUoQ+tAhkCOmShCkAKjg11XXqY024DYdySypY/eDjF7WoNJeVXS1nIsgPNfpoMKh2yk6t//MmZgeuwb7FuVEoJ63qUpyXDnICHOyfo6m8=
   - secure: Sp/QRPI2M1wGNg14DqsN3N4l6OwKLHEMf7V4qsYnhOIlirEpMfJ3OnG0VHoNwK9Yq/hOaL6g802WvwUgAkNQnyXF85gWFo5bsuDxqogwFWp0bb7s1BAjolZ06z79D+LCtZAsMOFpxFXY+fg1goc8F8XxVOvkwo0wsSNiSKN62aI=
   - secure: N58wuHe+HiUI6L31EBjWplRmErAXb9DdmNJo2lefcjAAUDJfvQF5/qO4pyXRoSBThPygkpx0a4UyR3JblLUdCKebnT5/e7PqEpbImDEpKFwPGa2onA1EcEq+tDgcAuAE8TH1SLC2z/lPKJXmLhvTCx5zRNZ9Z5nzsHZdwpnd1gc=
+  - secure: FNvhD0mL8Q1kT2GUDUEB+wwIyMga/ejt9niYbbRcbZqrBGabeiVf5hDG2QlM/nq7FYXo5IGTkMre9lztKgc5hnGYVRWfOCS57RvEysbE6UTj/aEOWsKDJcmVDajt/dwxlFUrOBCo16QEREsk9xb/V9BvNNr4H8Nn1YaowTmy9g4=
 before_install:
   - sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
   - export DISPLAY=:99.0
@@ -15,3 +16,4 @@ before_install:
 install:
   - bundle
   - rake &
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,17 @@ language: ruby
 rvm: 2.2.0
 notifications:
   email: false
-script: rake test:all
+script: xvfb-run rake test:all
 services: mongodb
 env:
   global:
+  - DISPLAY=:99.0
   - secure: Nh4Vc1EEgs+C7rqTauvCJaehvsI6hQiYtm/ttzIirDjCJt0P0jgm0ZZoqESItz5SQUEUoQ+tAhkCOmShCkAKjg11XXqY024DYdySypY/eDjF7WoNJeVXS1nIsgPNfpoMKh2yk6t//MmZgeuwb7FuVEoJ63qUpyXDnICHOyfo6m8=
   - secure: Sp/QRPI2M1wGNg14DqsN3N4l6OwKLHEMf7V4qsYnhOIlirEpMfJ3OnG0VHoNwK9Yq/hOaL6g802WvwUgAkNQnyXF85gWFo5bsuDxqogwFWp0bb7s1BAjolZ06z79D+LCtZAsMOFpxFXY+fg1goc8F8XxVOvkwo0wsSNiSKN62aI=
   - secure: N58wuHe+HiUI6L31EBjWplRmErAXb9DdmNJo2lefcjAAUDJfvQF5/qO4pyXRoSBThPygkpx0a4UyR3JblLUdCKebnT5/e7PqEpbImDEpKFwPGa2onA1EcEq+tDgcAuAE8TH1SLC2z/lPKJXmLhvTCx5zRNZ9Z5nzsHZdwpnd1gc=
   - secure: FNvhD0mL8Q1kT2GUDUEB+wwIyMga/ejt9niYbbRcbZqrBGabeiVf5hDG2QlM/nq7FYXo5IGTkMre9lztKgc5hnGYVRWfOCS57RvEysbE6UTj/aEOWsKDJcmVDajt/dwxlFUrOBCo16QEREsk9xb/V9BvNNr4H8Nn1YaowTmy9g4=
 before_install:
   - sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d xvfb start
 install:
   - bundle
   - rake &

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
   - secure: Sp/QRPI2M1wGNg14DqsN3N4l6OwKLHEMf7V4qsYnhOIlirEpMfJ3OnG0VHoNwK9Yq/hOaL6g802WvwUgAkNQnyXF85gWFo5bsuDxqogwFWp0bb7s1BAjolZ06z79D+LCtZAsMOFpxFXY+fg1goc8F8XxVOvkwo0wsSNiSKN62aI=
   - secure: N58wuHe+HiUI6L31EBjWplRmErAXb9DdmNJo2lefcjAAUDJfvQF5/qO4pyXRoSBThPygkpx0a4UyR3JblLUdCKebnT5/e7PqEpbImDEpKFwPGa2onA1EcEq+tDgcAuAE8TH1SLC2z/lPKJXmLhvTCx5zRNZ9Z5nzsHZdwpnd1gc=
 before_install:
-- sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
+  - sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev; fi'
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d xvfb start
 install:
   - bundle
   - rake &

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Environment variables:
 * `PUBLIC_KEY`
     * required
     * Retrieve a public key from Trello by visiting [https://trello.com/1/appKey/generate](https://trello.com/1/appKey/generate).
+* `TRELLO_TEST_DISPLAY_NAME`
+    * required
+    * Display name to use while running cukes (this is your `@<username>` from Trello)
 * `TRELLO_TEST_USERNAME`
     * required
     * Username to use while running cukes

--- a/test/features/Settings.feature
+++ b/test/features/Settings.feature
@@ -36,10 +36,8 @@ Scenario: Connecting to a different Trello account
   Then I should not see "Connecting..."
   And I should not see "Redirecting..."
   And I should be on the boards page
-  Given I go to the settings page
-  When I follow "Connect to a Different Trello Account"
-  And I authorize with Trello
-  And the test user "trello_name" should be "ollerttest"
+  When I go to the settings page
+  Then I am able to connect to an alternative Trello account
 
 @javascript
 Scenario: Connecting to Trello with previously-used Trello account

--- a/test/features/step_definitions/settings_steps.rb
+++ b/test/features/step_definitions/settings_steps.rb
@@ -43,3 +43,9 @@ end
 When(/^I click my avatar$/) do
   find(".settings-link").click
 end
+
+Then(/^I am able to connect to an alternative Trello account$/) do
+  click_link('Connect to a Different Trello Account')
+  step 'I authorize with Trello'
+  expect(User.first[:trello_name]).to eq(Environment.test_display_name)
+end

--- a/test/features/support/environment.rb
+++ b/test/features/support/environment.rb
@@ -1,5 +1,9 @@
 class Environment
   class << self
+    def test_display_name
+      ENV['TRELLO_TEST_DISPLAY_NAME']
+    end
+
     def test_username
       ENV['TRELLO_TEST_USERNAME']
     end


### PR DESCRIPTION
*  added a `.travis.yml` to be able to run builds within Travis CI
  * did `travis encrypt` on my own personal `.env`, so this is what the builds use (just a note)
*  updates `Settings.feature:32` to use the `ENV` rather than the hard-coded `ollerttest` account
  * added a `TRELLO_TEST_DISPLAY_NAME` to support this as well as updated the `README`