### PR TITLE
Use Container Based travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+sudo: false
 language: ruby
 rvm: 2.2.0
 notifications:
   email: false
 script: xvfb-run rake test:all
 services: mongodb
+cache: bundler
 env:
   global:
   - DISPLAY=:99.0
@@ -15,10 +17,6 @@ env:
   - secure: d1eEQH6CsyEitrJwmfK5bzDVoKa3ZWskaLxKrRlcUdVzyDReaBb2RhhPFkNmJnOmcQYSHfEIqmon7GDS/Uf375VL9zRpcTh08hRb+UQIj/Wr1PUsPEO0TytIA6bA9Kudp5TPx3Ky77uW64OY4y/Ihae4rH193JVobNgtJcdrNUw=
   - secure: gIYwEOTgmCsDuzs/23IMkx7zAq/gXIHREf+c0EQ8FCEjUJjfa5Iwtrzi6U+ylwXspXHBx3Cslt1NYNcL25r29f9RAA73tONVyxevilae5bdytZzgt1i3Y5lPEPNWX28U8JdDqyyvt6AJnaOkDt8Jbsmj9R8HJOuVXSJeZb4lDjI=
   - secure: k3gSQaWUFqZwpiRHkUs30XBIAg/AJoWIGxLJnNOmJN30MpnP4BoO0aCv/yOS1XOePi741iPzbS56EkwZFPEppL+f3s+m4063+b/ff9AL5ykY1zePxSp+W7hLIRfO9dF8xsnWOKGixjgrEByXd4FaJpQKO5mG61uJD45Ay3Y1dX8=
-before_install:
-- sh -c 'if [ -n "$QMAKE" ]; then sudo apt-add-repository -y ppa:ubuntu-sdk-team/ppa
-  && sudo apt-get update && sudo apt-get install libqt5webkit5-dev qtdeclarative5-dev;
-  fi'
 install:
 - npm install testem -g
 - bundle

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ brew install phantomjs
 ```
 
 #### CI
-
-We are working on getting a Travis build up and running. Be patient.
+Travis CI is being used for CI. For clones of this repository, builds will run in your `https://travis-ci.org/<your username>/ollert` environment. Since the tests depend on the environment variables mentioned above, those also need to be carried over in your individual Travis CI setup. Please look at the documentation for [environment variables](http://docs.travis-ci.com/user/environment-variables/#Using-Settings) for more information about setting up your environment variables.
 
 ### Contributing
 


### PR DESCRIPTION
# Description
This sets up the travis-ci to use travis-ci's [container-based infrastructure](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/).

# Changes to `.travis.yml`
*  add `sudo: false` to indicate we want to use container-based
*  added the `cache: bundler` to speed up the `bundle` command
*  removed all `sudo` commands since this is not supported in container-based builds
  *  turns out that these were not required anyway to be able to run webkit, at least in [my builds](https://travis-ci.org/leviwilson/ollert/builds/53076983)
