### PR TITLE
Display Board Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Environment variables:
 * `TRELLO_TEST_PASSWORD`
     * required
     * Password to use while running cukes
-* `INTEGRATION_KEY` / `INTEGRATION_TOKEN`
+* `MEMBER_TOKEN`
     * required
-    * these values are used to run the integration tests. To generate these values after you have entered your `PUBLIC_KEY` run the following command and paste the result into your `.env` file where it asks you to:
+    * this value is used to run the integration tests. To generate this value after you have entered your `PUBLIC_KEY` run the following command and paste the result into your `.env` file where it asks you to:
 ```
 rake test:setup
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -52,10 +52,6 @@ unless ENV['RACK_ENV'] == 'production'
       Dotenv.load
       raise 'PUBLIC_KEY is not part of your .env' unless ENV['PUBLIC_KEY']
 
-      File.open('.env', 'a') do |f|
-        f.puts "INTEGRATION_KEY=#{ENV['PUBLIC_KEY']}"
-        f.puts 'INTEGRATION_TOKEN=<value copied after accepting>'
-      end
       Launchy.open "https://trello.com/1/authorize?key=#{ENV['PUBLIC_KEY']}&scope=read%2Cwrite&name=OllertIntegrationTests&expiration=never&response_type=token"
       puts "Copy the value shown to you after you choose to 'Allow' the Ollert Integration Tests application"
     end

--- a/helpers.rb
+++ b/helpers.rb
@@ -1,0 +1,7 @@
+module OllertApp
+  module Helpers
+    def title_for(what=nil)
+      "- #{what}" if what
+    end
+  end
+end

--- a/routes/board_routes.rb
+++ b/routes/board_routes.rb
@@ -81,7 +81,7 @@ class Ollert
 
     @board_id = board_id
 
-    @title = "#{@board_name} Board"
+    @title = @board_name
     haml :analysis
   end
 

--- a/routes/board_routes.rb
+++ b/routes/board_routes.rb
@@ -81,6 +81,7 @@ class Ollert
 
     @board_id = board_id
 
+    @title = "#{@board_name} Board"
     haml :analysis
   end
 

--- a/test/features/BoardDetails.feature
+++ b/test/features/BoardDetails.feature
@@ -7,3 +7,7 @@ Feature: BoardDetails
 Scenario: View board
   When I choose to connect with Trello
   Then I can drill into the board named "Empty Board"
+
+Scenario: Updating the title
+  When I am viewing the board "Test Board #1"
+  Then the page title reflects the current board I am viewing

--- a/test/features/step_definitions/board_details_steps.rb
+++ b/test/features/step_definitions/board_details_steps.rb
@@ -2,3 +2,12 @@ Then(/^I can drill into the board named "([^"]*)"$/) do |board_name|
   on(BoardsPage).choose board_name
   expect(on(BoardDetails).current_board).to eq(board_name)
 end
+
+When(/^I am viewing the board "([^"]*)"$/) do |board_name|
+  @expected_board_title = board_name
+  navigate_to(BoardsPage, using: :boards_route).choose board_name
+end
+
+Then(/^the page title reflects the current board I am viewing$/) do
+  expect(on(BoardDetails).title).to eq "Ollert - #{@expected_board_title} Board"
+end

--- a/test/features/step_definitions/board_details_steps.rb
+++ b/test/features/step_definitions/board_details_steps.rb
@@ -4,6 +4,8 @@ Then(/^I can drill into the board named "([^"]*)"$/) do |board_name|
 end
 
 When(/^I am viewing the board "([^"]*)"$/) do |board_name|
+  TrelloIntegrationHelper.add_list('Test List')
+
   @expected_board_title = board_name
   navigate_to(BoardsPage, using: :boards_route).choose board_name
 end

--- a/test/features/step_definitions/board_details_steps.rb
+++ b/test/features/step_definitions/board_details_steps.rb
@@ -11,5 +11,5 @@ When(/^I am viewing the board "([^"]*)"$/) do |board_name|
 end
 
 Then(/^the page title reflects the current board I am viewing$/) do
-  expect(on(BoardDetails).title).to eq "Ollert - #{@expected_board_title} Board"
+  expect(on(BoardDetails).title).to eq "Ollert - #{@expected_board_title}"
 end

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -12,8 +12,7 @@ require 'site_prism'
 require 'capybara/webkit'
 require 'require_all'
 
-require_rel '../../../web'
-require_rel '../../lib'
+require_rel '../../../web', '../../spec/trello_integration_helper', '../../lib'
 
 Capybara.app = Ollert
 Capybara.default_wait_time = 10
@@ -28,3 +27,9 @@ end
 World(OllertTest::Navigation) do
   Ollert.new
 end
+
+Trello.configure do |config|
+  config.developer_public_key = ENV['INTEGRATION_KEY']
+  config.member_token = ENV['INTEGRATION_TOKEN']
+end
+

--- a/test/features/support/env.rb
+++ b/test/features/support/env.rb
@@ -29,7 +29,7 @@ World(OllertTest::Navigation) do
 end
 
 Trello.configure do |config|
-  config.developer_public_key = ENV['INTEGRATION_KEY']
-  config.member_token = ENV['INTEGRATION_TOKEN']
+  config.developer_public_key = ENV['PUBLIC_KEY']
+  config.member_token = ENV['MEMBER_TOKEN']
 end
 

--- a/test/features/support/hooks.rb
+++ b/test/features/support/hooks.rb
@@ -17,4 +17,6 @@ After do
 
     client.delete("/tokens/#{user.member_token}")
   end
+
+  TrelloIntegrationHelper.cleanup
 end

--- a/test/features/support/routes.rb
+++ b/test/features/support/routes.rb
@@ -3,5 +3,10 @@ OllertTest::Navigation.routes = {
       [LandingPage, :lets_get_started],
       [LoginPage, :login_with_my_account],
       [SettingsPage]
+    ],
+    boards_route: [
+      [LandingPage, :lets_get_started],
+      [LoginPage, :login_with_my_account],
+      [BoardsPage]
     ]
 }

--- a/test/spec/helpers_spec.rb
+++ b/test/spec/helpers_spec.rb
@@ -1,0 +1,15 @@
+require_relative 'spec_helper'
+
+describe OllertApp::Helpers do
+  let(:helper) { Class.new { extend OllertApp::Helpers } }
+
+  context '#title_for' do
+    it 'is empty if nothing is provided' do
+      expect(helper.title_for).to be_nil
+    end
+
+    it 'prefixes a hyphen with whatever is passed in' do
+      expect(helper.title_for 'expected').to eq '- expected'
+    end
+  end
+end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'dotenv'
 require 'trello_integration_helper'
 
 require_rel '../../utils'
+require_rel '../../helpers'
+
 Dotenv.load File.join(File.dirname(__FILE__), '../../', '.env')
 
 Trello.configure do |config|

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -12,8 +12,8 @@ require_rel '../../helpers'
 Dotenv.load File.join(File.dirname(__FILE__), '../../', '.env')
 
 Trello.configure do |config|
-  config.developer_public_key = ENV['INTEGRATION_KEY']
-  config.member_token = ENV['INTEGRATION_TOKEN']
+  config.developer_public_key = ENV['PUBLIC_KEY']
+  config.member_token = ENV['MEMBER_TOKEN']
 end
 
 RSpec.configure do |config|

--- a/test/spec/trello_integration_helper.rb
+++ b/test/spec/trello_integration_helper.rb
@@ -8,20 +8,25 @@ class TrelloIntegrationHelper
     board.id
   end
 
-  def self.add_card
-    Trello::Card.create list_id: first_list.id, name: "Card ##{next_card}"
+  def self.add_card(list_id=first_list.id)
+    Trello::Card.create list_id: list_id, name: "Card ##{next_card}"
+  end
+
+  def self.add_list(name)
+    lists << Trello::List.create(board_id: board.id, name: name)
+    lists.last
   end
 
   def self.first_list
-    @first_list ||= Trello::List.create(board_id: board.id, name: 'Integration Test List #1')
+    @first_list ||= add_list('Integration Test List #1')
   end
 
   def self.second_list
-    @second_list ||= Trello::List.create(board_id: board.id, name: 'Integration Test List #2')
+    @second_list ||= add_list('Integration Test List #2')
   end
 
   def self.cleanup
-    [@first_list, @second_list].compact.each do |list|
+    lists.compact.each do |list|
       list.close!
     end
   end
@@ -35,8 +40,12 @@ class TrelloIntegrationHelper
       @next_card ||= 0
       @next_card += 1
     end
+
+    def lists
+      @lists ||= []
+    end
   end
 
-  private_class_method :board, :next_card
+  private_class_method :board, :next_card, :lists
 end
 

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -1,7 +1,7 @@
 !!! html
 %html{lang: 'en'}
   %head
-    %title Ollert
+    %title Ollert #{title_for @title}
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1.0'}
     %meta{name: 'description', content: 'Free Trello Analytics and Statistics, including Cumulative Flow Diagram and Work In Progress'}
     %meta{name: 'author', content: 'Larry Price <larry@ollertapp.com>'}

--- a/web.rb
+++ b/web.rb
@@ -5,8 +5,11 @@ require 'rack/ssl'
 require 'rack/rewrite'
 require 'sinatra/base'
 require 'sinatra/respond_with'
+require_relative 'helpers'
 
 class Ollert < Sinatra::Base
+  helpers OllertApp::Helpers
+
   register Sinatra::RespondWith
   configure :development do
     require 'sinatra/reloader'


### PR DESCRIPTION
![board_titles](https://cloud.githubusercontent.com/assets/574434/6759780/31efe00c-cf19-11e4-860c-91be3dc56d3f.gif)

This pull request updates the board details page to reflect the name of the board that you are viewing in the title bar. This makes it easier to delineate in your browser history what you were looking at as requested in #13.