### PR TITLE
Exclude Archived Cards from Time In Lists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ end
 group :development, :test do
   gem 'dotenv'
   gem 'rspec'
+  gem 'rspec-its'
   gem 'cucumber'
   gem 'capybara'
   gem 'rack_session_access'
@@ -35,4 +36,7 @@ group :development, :test do
   gem 'site_prism'
   gem 'page_navigation'
   gem 'selenium-webdriver'
+  gem 'factory_girl'
+  gem 'activesupport'
+  gem 'faker', '~> 1.6.6'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,5 @@ group :development, :test do
   gem 'factory_girl'
   gem 'activesupport'
   gem 'faker', '~> 1.6.6'
+  gem 'timecop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rack-flash3'
 gem 'rack-ssl'
 gem 'rack-rewrite'
 gem 'mongoid'
-gem 'ruby-trello'
+gem 'ruby-trello', '~> 1.4.2'
 gem 'business_time'
 gem 'require_all'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,9 @@ GEM
       yml_reader (>= 0.4)
     diff-lcs (1.2.5)
     dotenv (2.0.2)
-    faker (1.5.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    faker (1.6.6)
       i18n (~> 0.5)
     ffi (1.9.10)
     foreman (0.78.0)
@@ -109,6 +111,9 @@ GEM
     rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
@@ -161,6 +166,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   bundler
   business_time
   capybara
@@ -168,6 +174,8 @@ DEPENDENCIES
   chronic
   cucumber
   dotenv
+  factory_girl
+  faker (~> 1.6.6)
   foreman
   haml
   launchy
@@ -181,6 +189,7 @@ DEPENDENCIES
   rake
   require_all
   rspec
+  rspec-its
   ruby-trello
   sass
   selenium-webdriver
@@ -189,3 +198,6 @@ DEPENDENCIES
   sinatra-reloader
   site_prism
   unicorn
+
+BUNDLED WITH
+   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -205,6 +206,7 @@ DEPENDENCIES
   sinatra-contrib
   sinatra-reloader
   site_prism
+  timecop
   unicorn
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       faker (>= 1.1.2)
       yml_reader (>= 0.4)
     diff-lcs (1.2.5)
+    domain_name (0.5.20160615)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.0.2)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -54,6 +56,8 @@ GEM
     gherkin3 (3.1.1)
     haml (4.0.7)
       tilt
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     kgio (2.10.0)
@@ -72,7 +76,7 @@ GEM
       tzinfo (>= 0.3.37)
     multi_json (1.11.2)
     multi_test (0.1.2)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth (0.4.7)
@@ -99,7 +103,8 @@ GEM
     raindrops (0.15.0)
     rake (10.4.2)
     require_all (1.3.2)
-    rest-client (1.7.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec (3.3.0)
@@ -118,12 +123,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    ruby-trello (1.2.1)
+    ruby-trello (1.4.2)
       activemodel (>= 3.2.0)
       addressable (~> 2.3)
       json
       oauth (~> 0.4.5)
-      rest-client (~> 1.7.2)
+      rest-client (~> 1.8.0)
     rubyzip (1.1.7)
     sass (3.4.18)
     selenium-webdriver (2.47.1)
@@ -153,6 +158,9 @@ GEM
     tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -190,7 +198,7 @@ DEPENDENCIES
   require_all
   rspec
   rspec-its
-  ruby-trello
+  ruby-trello (~> 1.4.2)
   sass
   selenium-webdriver
   sinatra

--- a/Rakefile
+++ b/Rakefile
@@ -39,12 +39,12 @@ unless ENV['RACK_ENV'] == 'production'
   namespace :test do
     RSpec::Core::RakeTask.new(:spec) do |r|
       r.pattern = "test/**/*_spec.rb"
-      r.rspec_opts = '--color --format documentation --tag ~integration:true'
+      r.rspec_opts = '--color --format documentation --require ./test/spec/spec_helper --tag ~integration:true'
     end
 
     RSpec::Core::RakeTask.new(:integration) do |r|
       r.pattern = "test/**/*_spec.rb"
-      r.rspec_opts = '--color --format documentation --tag integration:true'
+      r.rspec_opts = '--color --format documentation --require ./test/spec/spec_helper --tag integration:true'
     end
 
     desc 'Setup Integration'

--- a/routes/analysis_routes.rb
+++ b/routes/analysis_routes.rb
@@ -23,10 +23,12 @@ class Ollert
 
   get '/api/v1/listchanges/:board_id' do |board_id|
     lists = @client.get("/boards/#{board_id}/lists", filter: 'open').json_into(Trello::List)
+    cards = @client.get("/boards/#{board_id}/cards").json_into(Trello::Card)
     all = Utils::Fetchers::ListActionFetcher.fetch(@client, board_id)
 
     {
-      lists: lists.map {|l| {id: l.id, name: l.name}},
+      lists: lists.map {|l| l.attributes.slice(:id, :name) },
+      cards: cards.map { |c| c.attributes.slice(:id, :name, :list_id, :closed) },
       times: Utils::Analyzers::TimeTracker.by_card(all)
     }.to_json
   end

--- a/routes/analysis_routes.rb
+++ b/routes/analysis_routes.rb
@@ -23,7 +23,7 @@ class Ollert
 
   get '/api/v1/listchanges/:board_id' do |board_id|
     lists = @client.get("/boards/#{board_id}/lists", filter: 'open').json_into(Trello::List)
-    cards = @client.get("/boards/#{board_id}/cards").json_into(Trello::Card)
+    cards = @client.get("/boards/#{board_id}/cards", fields: 'name,closed,idList,idBoard,shortUrl').json_into(Trello::Card)
     actions = Utils::Fetchers::ListActionFetcher.fetch(@client, board_id)
 
     {

--- a/routes/analysis_routes.rb
+++ b/routes/analysis_routes.rb
@@ -9,25 +9,21 @@ class Ollert
       if params["token"].nil?
         halt 400, "Missing token."
       end
+
+      @client = Trello::Client.new(developer_public_key: ENV['PUBLIC_KEY'],
+                                   member_token: params['token'])
     end
   end
 
   get '/api/v1/progress/:board_id' do |board_id|
-    client = Trello::Client.new(
-      :developer_public_key => ENV['PUBLIC_KEY'],
-      :member_token => params["token"]
-    )
-
-    body ProgressChartsAnalyzer.analyze(ProgressChartsFetcher.fetch(client, board_id),
+    body ProgressChartsAnalyzer.analyze(ProgressChartsFetcher.fetch(@client, board_id),
      params["startingList"], params["endingList"]).to_json
     status 200
   end
 
   get '/api/v1/listchanges/:board_id' do |board_id|
-    client = Trello::Client.new developer_public_key: ENV['PUBLIC_KEY'], member_token: params['token']
-
-    lists = client.get("/boards/#{board_id}/lists", filter: 'open').json_into(Trello::List)
-    all = Utils::Fetchers::ListActionFetcher.fetch(client, board_id)
+    lists = @client.get("/boards/#{board_id}/lists", filter: 'open').json_into(Trello::List)
+    all = Utils::Fetchers::ListActionFetcher.fetch(@client, board_id)
 
     {
       lists: lists.map {|l| {id: l.id, name: l.name}},
@@ -36,32 +32,17 @@ class Ollert
   end
 
   get '/api/v1/wip/:board_id' do |board_id|
-    client = Trello::Client.new(
-      :developer_public_key => ENV['PUBLIC_KEY'],
-      :member_token => params["token"]
-    )
-
-    body WipAnalyzer.analyze(WipFetcher.fetch(client, board_id)).to_json
+    body WipAnalyzer.analyze(WipFetcher.fetch(@client, board_id)).to_json
     status 200
   end
 
   get '/api/v1/stats/:board_id' do |board_id|
-    client = Trello::Client.new(
-      :developer_public_key => ENV['PUBLIC_KEY'],
-      :member_token => params['token']
-    )
-
-    body StatsAnalyzer.analyze(StatsFetcher.fetch(client, board_id)).to_json
+    body StatsAnalyzer.analyze(StatsFetcher.fetch(@client, board_id)).to_json
     status 200
   end
 
   get '/api/v1/labels/:board_id' do |board_id|
-    client = Trello::Client.new(
-      :developer_public_key => ENV['PUBLIC_KEY'],
-      :member_token => params['token']
-    )
-
-    body LabelCountAnalyzer.analyze(LabelCountFetcher.fetch(client, board_id)).to_json
+    body LabelCountAnalyzer.analyze(LabelCountFetcher.fetch(@client, board_id)).to_json
     status 200
   end
 end

--- a/routes/analysis_routes.rb
+++ b/routes/analysis_routes.rb
@@ -24,12 +24,11 @@ class Ollert
   get '/api/v1/listchanges/:board_id' do |board_id|
     lists = @client.get("/boards/#{board_id}/lists", filter: 'open').json_into(Trello::List)
     cards = @client.get("/boards/#{board_id}/cards").json_into(Trello::Card)
-    all = Utils::Fetchers::ListActionFetcher.fetch(@client, board_id)
+    actions = Utils::Fetchers::ListActionFetcher.fetch(@client, board_id)
 
     {
       lists: lists.map {|l| l.attributes.slice(:id, :name) },
-      cards: cards.map { |c| c.attributes.slice(:id, :name, :list_id, :closed) },
-      times: Utils::Analyzers::TimeTracker.by_card(all)
+      times: Utils::Analyzers::TimeTracker.by_card(cards: cards, actions: actions)
     }.to_json
   end
 

--- a/test/.rspec
+++ b/test/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/test/features/TimeInLists.feature
+++ b/test/features/TimeInLists.feature
@@ -1,7 +1,14 @@
 @existing_lists @javascript
 Feature: Looking at time spent in lists
 
-Scenario: Time in lists honors the start and end of work
+Background:
   Given I am viewing the board "Test Board #1"
   When my work begins with "List #2" and ends with "List #4"
+
+Scenario: Time in lists honors the start and end of work
   Then my Time Spent in Lists should start with "List #2" and end with "List #3"
+
+Scenario: Time in lists ignores archived cards
+  Given all of my cards have been archived
+  When I refresh my view
+  Then my Time Spent in Lists should reflect nothing, since all my cards are archived

--- a/test/features/TimeInLists.feature
+++ b/test/features/TimeInLists.feature
@@ -3,12 +3,12 @@ Feature: Looking at time spent in lists
 
 Background:
   Given I am viewing the board "Test Board #1"
-  When my work begins with "List #2" and ends with "List #4"
 
 Scenario: Time in lists honors the start and end of work
+  Given my work begins with "List #2" and ends with "List #4"
   Then my Time Spent in Lists should start with "List #2" and end with "List #3"
 
 Scenario: Time in lists ignores archived cards
-  Given all of my cards have been archived
+  Given some of my cards have been archived
   When I refresh my view
   Then my Time Spent in Lists should reflect nothing, since all my cards are archived

--- a/test/features/step_definitions/time_in_lists_steps.rb
+++ b/test/features/step_definitions/time_in_lists_steps.rb
@@ -7,3 +7,15 @@ Then(/^my Time Spent in Lists should start with "([^"]*)" and end with "([^"]*)"
   labels = on(BoardDetails).time_spent_labels
   expect([labels.first, labels.last]).to eq([start_of_work, prior_to_end_of_work])
 end
+
+Given(/^all of my cards have been archived$/) do
+  TrelloIntegrationHelper.archive_all_cards
+end
+
+When(/^I refresh my view$/) do
+  on(BoardDetails).refresh
+end
+
+Then(/^my Time Spent in Lists should reflect nothing, since all my cards are archived$/) do
+  expect(on(BoardDetails).time_spent_labels).to be_empty
+end

--- a/test/features/step_definitions/time_in_lists_steps.rb
+++ b/test/features/step_definitions/time_in_lists_steps.rb
@@ -8,8 +8,11 @@ Then(/^my Time Spent in Lists should start with "([^"]*)" and end with "([^"]*)"
   expect([labels.first, labels.last]).to eq([start_of_work, prior_to_end_of_work])
 end
 
-Given(/^all of my cards have been archived$/) do
-  TrelloIntegrationHelper.archive_all_cards
+Given(/^some of my cards have been archived$/) do
+  cards_not_in_three = TrelloIntegrationHelper.open_cards.select { |card| card.list.name != 'List #3' }
+  cards_not_in_three.each(&:close!)
+
+  @expected_labels = %w(List\ #3)
 end
 
 When(/^I refresh my view$/) do
@@ -17,5 +20,5 @@ When(/^I refresh my view$/) do
 end
 
 Then(/^my Time Spent in Lists should reflect nothing, since all my cards are archived$/) do
-  expect(on(BoardDetails).time_spent_labels).to be_empty
+  expect(on(BoardDetails).time_spent_labels).to eq @expected_labels
 end

--- a/test/lib/core_ext/list.rb
+++ b/test/lib/core_ext/list.rb
@@ -1,0 +1,8 @@
+module Trello
+  class List < BasicData
+    # Archives all the cards of the list
+    def archive_all_cards
+      client.post("/lists/#{id}/archiveAllCards")
+    end
+  end
+end

--- a/test/lib/core_ext/page.rb
+++ b/test/lib/core_ext/page.rb
@@ -16,6 +16,10 @@ module SitePrism
       wait_until { finished_all_ajax? }
     end
 
+    def refresh
+      visit current_path
+    end
+
     def self.the_current_page?
       page = self.new
 

--- a/test/routes/analysis_routes_spec.rb
+++ b/test/routes/analysis_routes_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'analysis routes' do
+  let(:trello_client) { double 'trello client' }
+  let(:token) { 'fake token' }
+
+  before do
+    expect(Trello::Client).to receive(:new)
+      .with(developer_public_key: ENV['PUBLIC_KEY'], member_token: 'fake token')
+      .and_return(trello_client)
+  end
+
+  describe '/api/v1/listchanges/:board_id' do
+    let(:board_id) { 'abc-def' }
+    let(:lists) { build_list(:trello_list, 5) }
+
+    before do
+      allow(Utils::Fetchers::ListActionFetcher).to receive(:fetch).and_return []
+
+      expect(trello_client).to receive(:get).with("/boards/#{board_id}/lists", filter: 'open')
+        .and_return(lists.to_json)
+
+      get "/api/v1/listchanges/#{board_id}", token: token
+    end
+
+    subject { last_response }
+
+    it { should be_ok }
+
+    context 'response' do
+      let(:expected_lists) do
+        lists.map { |l| { 'id' => l.id, 'name' => l.name } }
+      end
+
+      subject { json_response_body }
+
+      its(%w(lists)) { should match_array(expected_lists) }
+    end
+  end
+end

--- a/test/routes/analysis_routes_spec.rb
+++ b/test/routes/analysis_routes_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'analysis routes' do
       let(:actions) { [{id: 1}, {id: 2}] }
       subject {  Utils::Analyzers::TimeTracker }
 
-      it { should have_received(:by_card).with([{id: 1}, {id: 2}]) }
+      it { should have_received(:by_card).with(cards: cards, actions: [{id: 1}, {id: 2}]) }
     end
 
     context 'json' do
@@ -54,8 +54,9 @@ RSpec.describe 'analysis routes' do
 
       subject { json_response_body }
 
+      its(:keys) { should match_array(%w(lists times)) }
+
       its(%w(lists)) { should match_array(expected_lists) }
-      its(%w(cards)) { should match_array(expected_cards) }
       its(%w(times)) { should be_empty }
 
       context 'times' do

--- a/test/routes/analysis_routes_spec.rb
+++ b/test/routes/analysis_routes_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'analysis routes' do
       expect(trello_client).to receive(:get).with("/boards/#{board_id}/lists", filter: 'open')
         .and_return(lists.to_json)
 
-      expect(trello_client).to receive(:get).with("/boards/#{board_id}/cards")
+      expect(trello_client).to receive(:get).with("/boards/#{board_id}/cards", fields: 'name,closed,idList,idBoard,shortUrl')
         .and_return(cards.to_json)
 
       get "/api/v1/listchanges/#{board_id}", token: token

--- a/test/spec/factories.rb
+++ b/test/spec/factories.rb
@@ -1,0 +1,12 @@
+require 'active_support/core_ext/hash/keys'
+require 'faker'
+
+FactoryGirl.define do
+  factory :trello_list, class: Trello::List do
+    initialize_with { new(attributes.stringify_keys) }
+
+    id { SecureRandom.uuid }
+    name { Faker::StarWars.planet }
+    closed false
+  end
+end

--- a/test/spec/factories.rb
+++ b/test/spec/factories.rb
@@ -9,4 +9,12 @@ FactoryGirl.define do
     name { Faker::StarWars.planet }
     closed false
   end
+
+  factory :trello_card, class: Trello::Card do
+    initialize_with { new(attributes.stringify_keys) }
+
+    id { SecureRandom.uuid }
+    name { Faker::StarWars.quote }
+    closed false
+  end
 end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'dotenv'
 require 'rspec/its'
 
 require 'trello_integration_helper'
+require_rel '../lib/core_ext/list'
 
 require_rel '../../utils'
 require_rel '../../helpers'

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -31,7 +31,7 @@ module OllertSpecs
 end
 
 require 'factory_girl'
-FactoryGirl.definition_file_paths = %w(./spec/factories)
+FactoryGirl.definition_file_paths = [File.dirname(__FILE__) + '/factories']
 FactoryGirl.find_definitions
 
 RSpec.configure do |config|

--- a/test/spec/trello_integration_helper.rb
+++ b/test/spec/trello_integration_helper.rb
@@ -25,12 +25,13 @@ class TrelloIntegrationHelper
     @second_list ||= add_list('Integration Test List #2')
   end
 
-  def self.archive_all_cards
-    board.cards.each(&:close!)
+  def self.open_cards
+    board.cards(filter: :open)
   end
 
   def self.cleanup
     lists.compact.each do |list|
+      list.archive_all_cards
       list.close!
     end
   end

--- a/test/spec/trello_integration_helper.rb
+++ b/test/spec/trello_integration_helper.rb
@@ -25,6 +25,10 @@ class TrelloIntegrationHelper
     @second_list ||= add_list('Integration Test List #2')
   end
 
+  def self.archive_all_cards
+    board.cards.each(&:close!)
+  end
+
   def self.cleanup
     lists.compact.each do |list|
       list.close!

--- a/test/spec/utils/analyzers/label_count_analyzer_spec.rb
+++ b/test/spec/utils/analyzers/label_count_analyzer_spec.rb
@@ -28,11 +28,11 @@ describe LabelCountAnalyzer do
                {"labels" => [{"id" => "10", "color" => "pink"}]},
                {"labels" => [{"id" => "11", "color" => "mauve"}]}]
 
-      expect(LabelCountAnalyzer.analyze(cards)).to match({
-        :labels=>["yellow", "green", "Doing", "orange", "purple", "red", "sky", "Completed", "lime", "pink", "mauve"],
-        :colors=>["#fad900", "#41c200", "#0079bf", "#ff9f19", "#a632db", "#f54747", "#00c2e0", "#4d4d4d", "#45e660", "#ff78cb", "#b3b3b3"],
-        :counts=>[2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-      })
+      expect(LabelCountAnalyzer.analyze(cards)).to match(
+        labels: %w(yellow red Doing orange purple green sky Completed lime pink mauve),
+        colors: %w(#fad900 #f54747 #0079bf #ff9f19 #a632db #41c200 #00c2e0 #4d4d4d #45e660 #ff78cb #b3b3b3),
+        counts: [2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+      )
     end
   end
 end

--- a/test/spec/utils/analyzers/label_count_analyzer_spec.rb
+++ b/test/spec/utils/analyzers/label_count_analyzer_spec.rb
@@ -29,8 +29,8 @@ describe LabelCountAnalyzer do
                {"labels" => [{"id" => "11", "color" => "mauve"}]}]
 
       expect(LabelCountAnalyzer.analyze(cards)).to match(
-        labels: %w(yellow red Doing orange purple green sky Completed lime pink mauve),
-        colors: %w(#fad900 #f54747 #0079bf #ff9f19 #a632db #41c200 #00c2e0 #4d4d4d #45e660 #ff78cb #b3b3b3),
+        labels: %w(yellow Completed Doing green lime mauve orange pink purple red sky),
+        colors: %w(#fad900 #4d4d4d #0079bf #41c200 #45e660 #b3b3b3 #ff9f19 #ff78cb #a632db #f54747 #00c2e0),
         counts: [2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
       )
     end

--- a/test/spec/utils/analyzers/time_tracker_spec.rb
+++ b/test/spec/utils/analyzers/time_tracker_spec.rb
@@ -1,13 +1,16 @@
 require 'base64'
 require 'chronic'
 require 'active_support/core_ext/numeric/time'
+require 'timecop'
 
 describe Utils::Analyzers::TimeTracker do
-  let(:one_day_ago) { 1.day.ago.utc }
-  let(:three_days_ago) { 3.days.ago.utc }
-  let(:last_monday) { Chronic.parse('a week ago last Monday').utc }
-  let(:last_friday) { Chronic.parse('a week ago last Friday').utc }
+  let(:one_day_ago) { 1.day.ago }
+  let(:three_days_ago) { 3.days.ago }
+  let(:last_monday) { Chronic.parse('a week ago last Monday') }
+  let(:last_friday) { Chronic.parse('a week ago last Friday') }
   let(:card_id) { 1 }
+
+  around { |example| Timecop.freeze { example.run } }
 
   it 'created cards have only been in their original list' do
     time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
@@ -220,7 +223,7 @@ describe Utils::Analyzers::TimeTracker do
     end
 
     def previous_date
-      actions.last.date.to_datetime.utc.to_date
+      actions.last.date.to_date
     end
 
   end

--- a/test/spec/utils/analyzers/time_tracker_spec.rb
+++ b/test/spec/utils/analyzers/time_tracker_spec.rb
@@ -3,19 +3,21 @@ require 'chronic'
 require 'active_support/core_ext/numeric/time'
 
 describe Utils::Analyzers::TimeTracker do
-  let(:last_monday) { Chronic.parse 'a week ago last Monday' }
-  let(:last_friday) { Chronic.parse 'a week ago last Friday' }
+  let(:one_day_ago) { 1.day.ago.utc }
+  let(:three_days_ago) { 3.days.ago.utc }
+  let(:last_monday) { Chronic.parse('a week ago last Monday').utc }
+  let(:last_friday) { Chronic.parse('a week ago last Friday').utc }
   let(:card_id) { 1 }
 
   it 'created cards have only been in their original list' do
-    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
+    time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
 
     expect(time_in('backlog').total_days).to eq(3)
   end
 
   it 'handles when there has only been one movement' do
     time_tracked_for ActionBuilder
-      .create_card(:backlog, 1.day.ago)
+      .create_card(:backlog, one_day_ago)
       .move_card(:development)
 
     expect(time_in('backlog').total_days).to eq(1)
@@ -24,7 +26,7 @@ describe Utils::Analyzers::TimeTracker do
 
   it 'does the best it can when the createCard action is missing' do
     time_tracked_for ActionBuilder
-      .fake_missing_create(:development, :backlog, 3.days.ago)
+      .fake_missing_create(:development, :backlog, three_days_ago)
       .move_card(:qa)
 
     expect(time_in('development').total_days).to eq(1)
@@ -66,7 +68,7 @@ describe Utils::Analyzers::TimeTracker do
   end
 
   it 'exposes the times' do
-    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
+    time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
       .move_card(:development)
       .move_card(:passed)
 
@@ -75,7 +77,7 @@ describe Utils::Analyzers::TimeTracker do
   end
 
   it 'breaks multiple cards up' do
-    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
+    time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
       .move_card(:development)
       .create_card(:backlog, last_friday)
 
@@ -84,7 +86,7 @@ describe Utils::Analyzers::TimeTracker do
 
   context 'cards with no actions' do
     before do
-      time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
+      time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
         .move_card(:development)
         .copy_card_from_list
     end
@@ -218,7 +220,7 @@ describe Utils::Analyzers::TimeTracker do
     end
 
     def previous_date
-      actions.last.date.to_date
+      actions.last.date.to_datetime.utc.to_date
     end
 
   end

--- a/test/spec/utils/analyzers/time_tracker_spec.rb
+++ b/test/spec/utils/analyzers/time_tracker_spec.rb
@@ -140,16 +140,15 @@ describe Utils::Analyzers::TimeTracker do
   class ActionBuilder
     attr_reader :actions, :cards
 
-    def initialize(list, date, card_id)
+    def initialize(list, date)
       @actions = []
       @cards = []
       @next_id = 0
-      @card_id = card_id
       next_action(list, date.to_time, 'createCard')
     end
 
-    def self.create_card(list, date=Date.today, card_id=1)
-      ActionBuilder.new list, date, card_id
+    def self.create_card(list, date=Date.today)
+      ActionBuilder.new list, date
     end
 
     def create_card(list, date=Date.today)
@@ -162,8 +161,8 @@ describe Utils::Analyzers::TimeTracker do
       self
     end
 
-    def self.fake_missing_create(list, previous, date=Date.today, card_id=1)
-      builder = ActionBuilder.new list, date, card_id
+    def self.fake_missing_create(list, previous, date=Date.today)
+      builder = ActionBuilder.new list, date
       action = builder.actions.first
       action.instance_variable_set(:@before, previous.to_s)
       action.instance_variable_set(:@before_id, Base64.encode64(previous.to_s))
@@ -204,6 +203,7 @@ describe Utils::Analyzers::TimeTracker do
 
     def add_card
       @next_id += 1
+      @card_id = @next_id
       @cards << FactoryGirl.build(:trello_card, id: @next_id)
     end
 

--- a/test/spec/utils/analyzers/time_tracker_spec.rb
+++ b/test/spec/utils/analyzers/time_tracker_spec.rb
@@ -1,27 +1,22 @@
-require_relative '../../spec_helper'
 require 'base64'
 require 'chronic'
+require 'active_support/core_ext/numeric/time'
 
 describe Utils::Analyzers::TimeTracker do
-  let(:three_days_ago) { Date.today - 3 }
-  let(:one_day_ago) { Date.today - 1 }
   let(:last_monday) { Chronic.parse 'a week ago last Monday' }
   let(:last_friday) { Chronic.parse 'a week ago last Friday' }
   let(:card_id) { 1 }
 
   it 'created cards have only been in their original list' do
-    actions = ActionBuilder.create_card(:backlog, three_days_ago).actions
-
-    time_tracked_for(actions)
+    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
 
     expect(time_in('backlog').total_days).to eq(3)
   end
 
   it 'handles when there has only been one movement' do
     time_tracked_for ActionBuilder
-      .create_card(:backlog, one_day_ago)
+      .create_card(:backlog, 1.day.ago)
       .move_card(:development)
-      .actions
 
     expect(time_in('backlog').total_days).to eq(1)
     expect(time_in('development').total_days).to eq(0)
@@ -29,9 +24,8 @@ describe Utils::Analyzers::TimeTracker do
 
   it 'does the best it can when the createCard action is missing' do
     time_tracked_for ActionBuilder
-      .fake_missing_create(:development, :backlog, three_days_ago)
+      .fake_missing_create(:development, :backlog, 3.days.ago)
       .move_card(:qa)
-      .actions
 
     expect(time_in('development').total_days).to eq(1)
     expect(time_in('qa').total_days).to eq(2)
@@ -44,7 +38,6 @@ describe Utils::Analyzers::TimeTracker do
       .move_card(:failed)
       .move_card(:development)
       .move_card(:passed)
-      .actions
 
     expect(time_in('backlog').total_days).to eq(1)
     expect(time_in('qa').total_days).to eq(1)
@@ -53,12 +46,11 @@ describe Utils::Analyzers::TimeTracker do
   end
 
   it 'handles if the actions are out of chronological order' do
-    reversed_actions = ActionBuilder.create_card(:backlog, last_monday)
+    builder = ActionBuilder.create_card(:backlog, last_monday)
       .move_card(:development, 3)
       .move_card(:qa)
-      .actions.reverse
 
-    time_tracked_for(reversed_actions)
+    time_tracked_for(builder, reverse_actions: true)
 
     expect(time_in('backlog').total_days).to eq(3)
   end
@@ -66,7 +58,7 @@ describe Utils::Analyzers::TimeTracker do
   it 'additionally tracks business days as well' do
     time_tracked_for(ActionBuilder.create_card(:backlog, last_friday)
       .move_card(:development, 3) # monday
-      .actions)
+      )
 
     backlog_times = time_in('backlog')
     expect(backlog_times.total_days).to eq(3)
@@ -74,33 +66,40 @@ describe Utils::Analyzers::TimeTracker do
   end
 
   it 'exposes the times' do
-    time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
+    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
       .move_card(:development)
       .move_card(:passed)
-      .actions
 
     actual_lists = times_for(:card_id).times.keys.map {|l| Base64.decode64 l}
     expect(actual_lists).to eq(['backlog', 'development', 'passed'])
   end
 
   it 'breaks multiple cards up' do
-    time_tracked_for ActionBuilder.create_card(:backlog, three_days_ago)
+    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
       .move_card(:development)
       .create_card(:backlog, last_friday, 2)
-      .actions
 
-    expect(@time_tracked.map(&:card_id)).to eq([1, 2])
+    expect(@time_tracked.map { |time| time.card.id }).to eq([1, 2])
+  end
+
+  it 'ignores a card if there are missing actions' do
+    time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
+      .move_card(:development)
+      .copy_card_from_list
+
+    expect(@time_tracked.map { |time| time.card.id }).to eq([1])
   end
 
   it '#to_json' do
-    time_tracked_for ActionBuilder.create_card(:backlog, last_friday)
+    builder = ActionBuilder.create_card(:backlog, last_friday)
       .move_card(:development, 3)
-      .actions
+
+    time_tracked_for(builder)
 
     dev_time = time_in('development')
 
     expected_json = [{
-      card_id: 1,
+      card: builder.cards.first,
       times: {
         id_for('backlog') => {total_days: 3, business_days: 1},
         id_for('development') => {total_days: dev_time.total_days, business_days: dev_time.business_days}
@@ -110,12 +109,13 @@ describe Utils::Analyzers::TimeTracker do
     expect(@time_tracked.to_json).to eq(expected_json)
   end
 
-  def time_tracked_for(actions)
-    @time_tracked = Utils::Analyzers::TimeTracker.by_card(actions)
+  def time_tracked_for(builder, reverse_actions: false)
+    actions = reverse_actions ? builder.actions.reverse : builder.actions
+    @time_tracked = Utils::Analyzers::TimeTracker.by_card(cards: builder.cards, actions: actions)
   end
 
   def times_for(card_id=1)
-    @time_tracked.find {|t| t.card_id === 1}
+    @time_tracked.find {|t| t.card.id === 1}
   end
 
   def time_in(list)
@@ -127,10 +127,11 @@ describe Utils::Analyzers::TimeTracker do
   end
 
   class ActionBuilder
-    attr_reader :actions
+    attr_reader :actions, :cards
 
     def initialize(list, date, card_id)
       @actions = []
+      @cards = []
       @card_id = card_id
       next_action(list, date.to_time, 'createCard')
     end
@@ -142,6 +143,11 @@ describe Utils::Analyzers::TimeTracker do
     def create_card(list, date=Date.today, card_id)
       @card_id = card_id
       next_action(list, date.to_time, 'createCard')
+      self
+    end
+
+    def copy_card_from_list
+      @cards << FactoryGirl.build(:trello_card)
       self
     end
 
@@ -160,6 +166,11 @@ describe Utils::Analyzers::TimeTracker do
 
     private
     def next_action(list, date, type)
+      case type
+      when 'createCard'
+        @cards << FactoryGirl.build(:trello_card, id: @card_id)
+      end
+
       fields = {
         'id' => Base64.encode64(Time.now.to_s),
         'date' => date.iso8601,

--- a/test/spec/utils/analyzers/time_tracker_spec.rb
+++ b/test/spec/utils/analyzers/time_tracker_spec.rb
@@ -77,7 +77,7 @@ describe Utils::Analyzers::TimeTracker do
   it 'breaks multiple cards up' do
     time_tracked_for ActionBuilder.create_card(:backlog, 3.days.ago)
       .move_card(:development)
-      .create_card(:backlog, last_friday, 2)
+      .create_card(:backlog, last_friday)
 
     expect(@time_tracked.map { |time| time.card.id }).to eq([1, 2])
   end
@@ -152,8 +152,7 @@ describe Utils::Analyzers::TimeTracker do
       ActionBuilder.new list, date, card_id
     end
 
-    def create_card(list, date=Date.today, card_id)
-      @card_id = SecureRandom.uuid
+    def create_card(list, date=Date.today)
       next_action(list, date.to_time, 'createCard')
       self
     end

--- a/test/spec/utils/fetchers/fetcher_spec.rb
+++ b/test/spec/utils/fetchers/fetcher_spec.rb
@@ -1,18 +1,17 @@
-require_relative '../../spec_helper'
-
-class FakeFetcher
+class FakeFetcher < Trello::BasicData
   extend Utils::Fetcher
 
-  attr_reader :id, :date
-
-  def initialize(fields={})
-    @id = fields['id']
-    @date = fields['date']
-    @date = Date.parse(date) if date.is_a? String
-  end
+  register_attributes :id, :date
 
   def ==(other)
     id == other.id && date == other.date
+  end
+
+  def update_fields(fields)
+    attributes[:id] = fields['id']
+    fields['date'].tap do |date|
+      attributes[:date] = Date.parse(date) if date
+    end
   end
 end
 
@@ -71,7 +70,7 @@ describe Utils::Fetcher do
     end
 
     def setup_items(how_many, option={})
-      all = how_many.times.map {|n| FakeFetcher.new('id' =>  n, 'date' =>  Date.new(1998, 9, n + 1))}.reverse
+      all = how_many.times.map {|n| FakeFetcher.new('id' =>  n, 'date' =>  Date.new(1998, 9, n + 1).to_s)}.reverse
 
       to_json = ->(p) { 
         ((option[:is_hash] && p.map {|a| {'id' => a.id, 'date' => a.date}}) || p).to_json

--- a/utils/analyzers/label_count_analyzer.rb
+++ b/utils/analyzers/label_count_analyzer.rb
@@ -3,7 +3,7 @@ class LabelCountAnalyzer
     return {} if data.nil? || data.empty?
 
     labels = {labels: [], colors: [], counts: []}
-    data.map {|card| card["labels"]}.flatten.group_by {|label| label["id"]}.sort_by {|id, uses| -uses.count}.each do |id, uses|
+    data.map {|card| card["labels"]}.flatten.group_by {|label| label["id"]}.sort_by {|id, uses| [-uses.count, uses[0]['color'].downcase]}.each do |id, uses|
       labels[:labels] << ((uses[0]["name"].nil? || uses[0]["name"].empty?) ? uses[0]["color"] : uses[0]["name"])
       labels[:colors] << convert_color(uses[0]["color"])
       labels[:counts] << uses.count

--- a/utils/analyzers/label_count_analyzer.rb
+++ b/utils/analyzers/label_count_analyzer.rb
@@ -3,7 +3,7 @@ class LabelCountAnalyzer
     return {} if data.nil? || data.empty?
 
     labels = {labels: [], colors: [], counts: []}
-    data.map {|card| card["labels"]}.flatten.group_by {|label| label["id"]}.sort_by {|id, uses| [-uses.count, uses[0]['color'].downcase]}.each do |id, uses|
+    data.map {|card| card["labels"]}.flatten.group_by {|label| label["id"]}.sort_by {|id, uses| [-uses.count, (uses[0]['color'] || '').downcase]}.each do |id, uses|
       labels[:labels] << ((uses[0]["name"].nil? || uses[0]["name"].empty?) ? uses[0]["color"] : uses[0]["name"])
       labels[:colors] << convert_color(uses[0]["color"])
       labels[:counts] << uses.count

--- a/utils/analyzers/time_tracker.rb
+++ b/utils/analyzers/time_tracker.rb
@@ -6,7 +6,7 @@ module Utils
       attr_reader :card, :times
 
       def initialize(card, actions)
-        @actions = actions.sort_by(&:date)
+        @actions = actions ? actions.sort_by(&:date) : []
         @card = card
         @times = {}
 
@@ -16,7 +16,7 @@ module Utils
         end
 
         last = @actions.last
-        span_for(last.after_id).add last.date, DateTime.now.utc.to_date
+        span_for(last.after_id).add last.date, DateTime.now.utc.to_date if last
       end
 
       def in(list)
@@ -32,10 +32,7 @@ module Utils
 
       def self.by_card(cards:, actions:)
         grouped_actions = actions.group_by(&:card_id)
-        cards.map do |card|
-          found_actions = grouped_actions[card.id]
-          TimeTracker.new card, found_actions if found_actions
-        end.compact
+        cards.map { |c| TimeTracker.new c, grouped_actions[c.id] }
       end
 
       private

--- a/utils/analyzers/time_tracker.rb
+++ b/utils/analyzers/time_tracker.rb
@@ -48,8 +48,8 @@ module Utils
         end
 
         def add(start_time, end_time)
-          start_day = start_time.to_date
-          end_day = end_time.to_date
+          start_day = start_time.to_datetime.utc.to_date
+          end_day = end_time.to_datetime.utc.to_date
 
           @total_days += (end_day - start_day).numerator
           @business_days += start_day.business_days_until end_day

--- a/utils/analyzers/time_tracker.rb
+++ b/utils/analyzers/time_tracker.rb
@@ -3,11 +3,11 @@ require 'business_time'
 module Utils
   module Analyzers
     class TimeTracker
-      attr_reader :card_id, :times
+      attr_reader :card, :times
 
-      def initialize(card_id, actions)
+      def initialize(card, actions)
         @actions = actions.sort_by(&:date)
-        @card_id = card_id
+        @card = card
         @times = {}
 
         @actions.reduce(nil) do |last_date, action|
@@ -25,13 +25,17 @@ module Utils
 
       def as_json(opts={})
         {
-          card_id: card_id,
+          card: card,
           times: times
         }
       end
 
-      def self.by_card(actions)
-        actions.group_by(&:card_id).map {|id, card_actions| TimeTracker.new id, card_actions}
+      def self.by_card(cards:, actions:)
+        grouped_actions = actions.group_by(&:card_id)
+        cards.map do |card|
+          found_actions = grouped_actions[card.id]
+          TimeTracker.new card, found_actions if found_actions
+        end.compact
       end
 
       private

--- a/utils/analyzers/time_tracker.rb
+++ b/utils/analyzers/time_tracker.rb
@@ -16,7 +16,7 @@ module Utils
         end
 
         last = @actions.last
-        span_for(last.after_id).add last.date, DateTime.now.utc.to_date if last
+        span_for(last.after_id).add last.date, DateTime.now.to_date if last
       end
 
       def in(list)
@@ -48,8 +48,8 @@ module Utils
         end
 
         def add(start_time, end_time)
-          start_day = start_time.to_datetime.utc.to_date
-          end_day = end_time.to_datetime.utc.to_date
+          start_day = start_time.to_date
+          end_day = end_time.to_date
 
           @total_days += (end_day - start_day).numerator
           @business_days += start_day.business_days_until end_day

--- a/web.rb
+++ b/web.rb
@@ -6,6 +6,7 @@ require 'rack/rewrite'
 require 'sinatra/base'
 require 'sinatra/respond_with'
 require 'trello'
+require 'trello/core_ext/string'
 require_relative 'helpers'
 
 class Ollert < Sinatra::Base


### PR DESCRIPTION
## Description
This PR fixes #39 by not including cards that are archived. Additionally, rather than sending back simply the `card_id` as the payload, it sends back more information that could be leveraged to add additional functionality on the client-side as well.

### Other Things
* updated to the latest `ruby-trello`
* introduced `Rack::Test` to test controller methods
  * `rspec-its` and `factory_girl` came with it as well
* the `/api` methods were DRY'd up in their usage of `new`ing up the `Trello::Client`
* updated the label count analyzer to have a secondary sort based on the label name
  * locally I was running into issues with this as the order in CI was different than the order locally that came back; this makes the specs (as well as viewing it) more predictable when there are ties on the label counts