### PR TITLE
fix: acceptance tests - accessing boards without log in

### DIFF
--- a/test/lib/pages/landing_page.rb
+++ b/test/lib/pages/landing_page.rb
@@ -8,7 +8,7 @@ class LandingPage < SitePrism::Page
   link(:settings, 'a.settings-link')
   link(:logout, text: 'Log out')
 
-  label(:warning_status, 'div.alert.alert-warning')
+  label(:warning_status, 'div.alert.alert-danger')
 
   def logout
     settings


### PR DESCRIPTION
Fix failed test case:

```
  Scenario: Accessing while not logged in                           # /Users/employmenthero/projects/ollert/test/features/Settings.feature:3
    When I attempt to view my settings without logging in first     # test/features/step_definitions/settings_steps.rb:1
    Then I should be told that I have to login before I can do that # test/features/step_definitions/board_steps.rb:20
      Unable to find css "div.alert.alert-warning" (Capybara::ElementNotFound)
      ./test/lib/core_ext/accessors.rb:53:in `block (2 levels) in label'
      ./test/features/step_definitions/board_steps.rb:23:in `block (2 levels) in <top (required)>'
      ./test/lib/navigation.rb:9:in `on'
      ./test/features/step_definitions/board_steps.rb:21:in `/^I should be told that I have to login before I can do that$/'
      ./test/features/Settings.feature:5:in `Then I should be told that I have to login before I can do that'
```
